### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/ecowitt/manifest.json
+++ b/custom_components/ecowitt/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "ecowitt",
   "name": "Ecowitt Weather Station",
+  "version": "1.00",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecowitt",
   "requirements": [


### PR DESCRIPTION
Custom integrations now require a version key in their manifest file, this also means that all custom integrations now require a manifest file.
Custom integrations that do not have this will be blocked from loading if it’s missing a version in the manifest starting with Home Assistant 2021.6.