### PR TITLE
Fix Lightning strike timestamp error in 2022.3

### DIFF
--- a/custom_components/ecowitt/sensor.py
+++ b/custom_components/ecowitt/sensor.py
@@ -55,8 +55,7 @@ class EcowittSensor(EcowittEntity, SensorEntity):
                 if not isinstance(self._ws.last_values[self._key], int):
                     return STATE_UNKNOWN
                 return dt_util.as_local(
-                    dt_util.utc_from_timestamp(self._ws.last_values[self._key])
-                ).isoformat()
+                    dt_util.utc_from_timestamp(self._ws.last_values[self._key]))
             # Battery value is 0-5
             if self._dc == DEVICE_CLASS_BATTERY and self._uom == PERCENTAGE:
                 return self._ws.last_values[self._key] * 20.0


### PR DESCRIPTION
Fix the error:
```ValueError: Invalid datetime: sensor.last_lightning_strike has a timestamp device class but does not provide a datetime state but <class 'str'>```

in 2022.3 while in lieu of the integration being incorporated into core.